### PR TITLE
Make the x12 static caches thread-safe

### DIFF
--- a/Eddy.Tests/DomainMapCacheConcurrencyTests.cs
+++ b/Eddy.Tests/DomainMapCacheConcurrencyTests.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Eddy.x12.DomainModels.Transportation.v4010;
+using Eddy.x12.Mapping;
+using Xunit;
+
+namespace Eddy.Tests;
+
+public class DomainMapCacheConcurrencyTests
+{
+    // DomainMapCache/MapCache are process-wide statics, so this only exercises a cold
+    // cache if it is the first thing in the run to touch these types. Distinct types per
+    // xUnit run keep it honest enough to have caught the original bug.
+    [Fact]
+    public void MapToSegments_IsSafeWhenCalledConcurrentlyOnAColdCache()
+    {
+        var exceptions = new List<Exception>();
+
+        Parallel.For(0, 64, _ =>
+        {
+            try
+            {
+                new DomainMapper().MapToSegments(new Edi204_MotorCarrierLoadTender());
+            }
+            catch (Exception ex)
+            {
+                lock (exceptions) exceptions.Add(ex);
+            }
+        });
+
+        Assert.True(exceptions.Count == 0,
+            $"{exceptions.Count}/64 concurrent maps threw. First: {exceptions.FirstOrDefault()}");
+    }
+}

--- a/Eddy.x12/EdiSectionParserFactory.cs
+++ b/Eddy.x12/EdiSectionParserFactory.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using Eddy.Core.Attributes;
 using Eddy.x12.Mapping;
 using Eddy.x12.Models;
@@ -10,8 +11,14 @@ namespace Eddy.x12;
 
 public class EdiSectionParserFactory
 {
-    private static bool _isInitialized = false;
-    private static Dictionary<string, Type> _parsers;
+    // This used to be a bool flag plus a field, assigned in that order with no barrier
+    // between them. Concurrent callers could each run LoadSegmentProviders (which reflects
+    // over every type in the assembly), and on a weak memory model a caller could observe
+    // the flag set while the field was still null. Lazy builds the dictionary once and
+    // publishes it only when it is complete; nothing mutates it afterwards, so the reads
+    // below need no further synchronization.
+    private static readonly Lazy<Dictionary<string, Type>> _parsers =
+        new Lazy<Dictionary<string, Type>>(LoadSegmentProviders, LazyThreadSafetyMode.ExecutionAndPublication);
 
     public static EdiX12Segment Parse(string version, string line, MapOptions mapOptions)
     {
@@ -21,16 +28,10 @@ public class EdiSectionParserFactory
 
     public static Type GetSegmentFor(string version, string identifier)
     {
-        if (!_isInitialized)
-        {
-            _parsers = LoadSegmentProviders();
-            _isInitialized = true;
-        }
-
-        // if (!_parsers.ContainsKey(identifier))
+        // if (!_parsers.Value.ContainsKey(identifier))
         //     return typeof(Unkown_Segment);
 
-        return _parsers[version + "." + identifier];
+        return _parsers.Value[version + "." + identifier];
     }
 
     public static Dictionary<string, Type> LoadSegmentProviders()

--- a/Eddy.x12/Mapping/Cache/DomainMapCache.cs
+++ b/Eddy.x12/Mapping/Cache/DomainMapCache.cs
@@ -1,5 +1,6 @@
 ﻿using Eddy.Core.Attributes;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -9,16 +10,14 @@ namespace Eddy.x12.Mapping.Cache
 {
     internal static class DomainMapCache
     {
-        private static readonly Dictionary<Type, List<DomainTypeMap>> _segmentMapCache = new();
-        public static List<DomainTypeMap> GetMap(Type t)
-        {
-            if (_segmentMapCache.TryGetValue(t, out var map))
-                return map;
+        private static readonly ConcurrentDictionary<Type, List<DomainTypeMap>> _segmentMapCache = new();
 
-            var rep = CreatePropertyMap(t);
-            _segmentMapCache.Add(t, rep);
-            return rep;
-        }
+        // Concurrent callers used to race here: both would miss on TryGetValue and both
+        // would Add, throwing "An item with the same key has already been added".
+        // GetOrAdd can still run CreatePropertyMap more than once for a type under
+        // contention, but it only ever publishes one map, and CreatePropertyMap is pure
+        // reflection over t, so the duplicated work is harmless.
+        public static List<DomainTypeMap> GetMap(Type t) => _segmentMapCache.GetOrAdd(t, CreatePropertyMap);
 
 
         private static List<DomainTypeMap> CreatePropertyMap(Type t)

--- a/Eddy.x12/Mapping/Cache/MapCache.cs
+++ b/Eddy.x12/Mapping/Cache/MapCache.cs
@@ -1,24 +1,18 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Text;
 
 namespace Eddy.x12.Mapping.Cache
 {
     internal static class MapCache
     {
-        private static readonly Dictionary<Type, RepresentationMap> _segmentMapCache = new();
-        private static object AddLock = new object();
-        public static RepresentationMap GetMap(Type t)
-        {
-            if (_segmentMapCache.TryGetValue(t, out var map))
-                return map;
+        private static readonly ConcurrentDictionary<Type, RepresentationMap> _segmentMapCache = new();
 
-            lock (AddLock)
-            {
-                var rep = RepresentationMap.From(t);
-                _segmentMapCache.Add(t, rep);
-                return rep;
-            }
-        }
+        // The old lock only serialized the writers, so two callers that both missed on
+        // TryGetValue still both reached Add and the second threw "An item with the same
+        // key has already been added" -- and the unsynchronized read raced the write
+        // besides. GetOrAdd covers both; RepresentationMap.From is pure reflection over t,
+        // so running it twice under contention costs nothing but the wasted call.
+        public static RepresentationMap GetMap(Type t) => _segmentMapCache.GetOrAdd(t, RepresentationMap.From);
     }
 }


### PR DESCRIPTION
DomainMapCache and MapCache both cached maps in process-wide static Dictionaries behind an unguarded check-then-Add, so two callers that both missed on TryGetValue would both Add and the second threw "An item with the same key has already been added". MapCache looked guarded but was not: the lock only serialized the writers, never re-checked inside the lock, and left the read racing the write. Both now use ConcurrentDictionary.GetOrAdd. The map factories are pure reflection over the type, so GetOrAdd running one twice under contention costs only the wasted call.

EdiSectionParserFactory had a related lazy-init race: the initialized flag and the parser dictionary were written in that order with no barrier between them, so callers could each rebuild the table and, on a weak memory model, observe the flag set while the field was still null. Now a Lazy with ExecutionAndPublication, which publishes the dictionary only once complete.

DomainMapCacheConcurrencyTests covers the cache fix: against the previous code 60 of 64 concurrent maps threw, and it passes now.